### PR TITLE
Fix issues with `citar-org-node-has-notes`

### DIFF
--- a/citar-org-node.el
+++ b/citar-org-node.el
@@ -173,12 +173,11 @@ The returned function, when given a citekey, will return non-nil if
 there's an associated note.
 
 See also `citar-org-node-notes-config'."
-  (let ((hasnotes (make-hash-table :test 'equal))
-        (citekeys (hash-table-keys (citar-org-node--get-citekey-refs))))
-    (dolist (citekey citekeys)
+  (let ((hasnotes (make-hash-table :test 'equal)))
+    (dolist (citekey (org-mem-all-roam-refs))
       (puthash citekey t hasnotes))
-    (lambda (citekey)
-      (gethash citekey hasnotes))))
+    (lambda (ref-path)
+      (gethash (concat "@" ref-path) hasnotes))))
 
 (defun citar-org-node-open-note (candidate-string)
   "Open org-node node for CANDIDATE-STRING.


### PR DESCRIPTION
Hi, I had a small issues since the migration to org-node V3.

Basically the `citar-open` command wasn't able to show me which entries had available notes.

This wasn't an issues when opening note as the path were correctly identified.

What I found out was that for whatever reason it seems like `citekeys` in `citar-org-node-has-notes` was empty!

So what I did is use directly `org-mem-all-roam-refs` to create the hash-table.

Because of that I had to use the `ref-path` instead to get the correct hash.

I'm not sure this is the correct way to go about this as I didn't really understood the functionality of `citar-org-node--get-citekey-refs`. 

Let me know if it works for you or if it could be done better.